### PR TITLE
Fix H265/HEVC support

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
 			<A HREF="#" class=dllink download="encoded.webm">downloading</a> the resulting WEBM file.
 		</P>
 		<BUTTON class=gobutton>ENCODE</BUTTON>
-		<INPUT type="radio" id="vp8"  name="enco" value= "vp8" /><label>vp8 </label>
-		<INPUT type="radio" id="vp9"  name="enco" value= "vp9" checked /><label>vp9 </label>
-		<INPUT type="radio" id="h264" name="enco" value="h264" /><label>h264</label>
-		<INPUT type="radio" id="h265" name="enco" value="h265" /><label>h265</label>
+		<INPUT type="radio" id="vp8"  name="enco" value="video/webm;codecs=vp8" /><label>vp8</label>
+		<INPUT type="radio" id="vp9"  name="enco" value="video/webm;codecs=vp9" checked /><label>vp9</label>
+		<INPUT type="radio" id="h264" name="enco" value="video/mp4;codecs=avc1" /><label>h264</label>
+		<INPUT type="radio" id="h265" name="enco" value="video/mp4;codecs=hvc1" /><label>h265</label>
 		<P><CANVAS class=painting width=1280 height=720 style='width:640px;height:360px' border=1 /></P>
 		<P><VIDEO controls class=encvid width=640 height=360 border=1 /></P>
 		<P><A HREF="https://github.com/canonical/inbrowser-encode-test">GitHub project</A>
@@ -86,7 +86,7 @@ gobutton.addEventListener('click', function() {
 		var canvasStream = canvas.captureStream(60);
 		var mstream = new window.MediaStream(canvasStream.getVideoTracks());
 		var mediaRecorder = new MediaRecorder(mstream, {
-			mimeType: 'video/webm; codecs=' + encval,
+			mimeType: encval,
 			videoBitsPerSecond: 5000000
 		});
 		gobutton.disabled = true;


### PR DESCRIPTION
The relevant notes from the Chromium source are:

https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/mediarecorder/media_recorder_handler.cc;l=384-396;drc=3d0711d78cbda790954e547276858840c6dd6732

and

https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/mediarecorder/media_recorder_handler.cc;l=408-415;drc=3d0711d78cbda790954e547276858840c6dd6732

`hvc1` is the only accepted codec string for H265/HEVC and additionally requires the .mp4 container format instead of .webm.

Thus move both container format and codec to the INPUT value and, while on it, switch h264 to .mp4 as well - which then requires to use the preferred codec name avc1.

This was only tested with Chromium, with the `enable_hevc_parser_and_hw_decoder` build flag and `MediaRecorderHEVCSupport` runtime flag enabled, in an effort to improve hardware de- and encoding on Linux.

According to the linked comments it should also work on Safari, Firefox doesn't seem to implement HEVC at all.